### PR TITLE
fix(hero-canvas): Prevent non-finite value in createRadialGradient

### DIFF
--- a/js/hero-canvas.js
+++ b/js/hero-canvas.js
@@ -161,8 +161,11 @@ class HeroCanvas {
 
       if (distance < 100) {
         const force = (100 - distance) / 100;
-        particle.vx += (dx / distance) * force * 0.01;
-        particle.vy += (dy / distance) * force * 0.01;
+        // Check if distance is not zero (or very close to zero)
+        if (distance > 0.001) { 
+          particle.vx += (dx / distance) * force * 0.01;
+          particle.vy += (dy / distance) * force * 0.01;
+        }
       }
 
       // Update position


### PR DESCRIPTION
Addresses an issue in `hero-canvas.js` where `createRadialGradient` could fail due to non-finite coordinate or radius values.

The root cause was identified as a potential division by zero in the mouse interaction logic within the `updateParticles` function. If the calculated distance between the mouse and a particle was zero, subsequent calculations for particle velocity (`vx`, `vy`) could result in `NaN`. These `NaN` values would then propagate to the particle's `x` or `y` coordinates, causing `createRadialGradient` to fail.

The fix implements a guard condition: force calculations based on mouse proximity are now only applied if the `distance` is greater than a small epsilon (`0.001`). This prevents division by zero or very small numbers, ensuring particle coordinates remain finite.