### PR TITLE
🧪 Add unit tests for DomainSeparationTag in forge-ec-core

### DIFF
--- a/forge-ec-core/src/lib.rs
+++ b/forge-ec-core/src/lib.rs
@@ -1885,3 +1885,22 @@ pub mod test_utils {
         true
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_domain_separation_tag_new() {
+        let dst = DomainSeparationTag::new("suite_id_test", "dst_test");
+        assert_eq!(dst.suite_id, "suite_id_test");
+        assert_eq!(dst.dst, "dst_test");
+    }
+
+    #[test]
+    fn test_domain_separation_tag_as_bytes() {
+        let dst = DomainSeparationTag::new("suite", "tag");
+        let bytes = dst.as_bytes();
+        assert_eq!(bytes, b"suitetag");
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for `DomainSeparationTag::new` and `DomainSeparationTag::as_bytes` in `forge-ec-core/src/lib.rs`.
📊 **Coverage:** Tests cover the basic instantiation logic to ensure `suite_id` and `dst` fields are set properly, and check if `as_bytes` generates correct concatenated byte string.
✨ **Result:** The new tests successfully improve test coverage for basic configuration in `forge-ec-core`.

---
*PR created automatically by Jules for task [1681398144214152094](https://jules.google.com/task/1681398144214152094) started by @tanm-sys*