### PR TITLE
🧹 [code health] Remove unused constant P from Curve25519

### DIFF
--- a/forge-ec-curves/src/curve25519.rs
+++ b/forge-ec-curves/src/curve25519.rs
@@ -13,13 +13,6 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use zeroize::Zeroize;
 // Removed unused imports - sha2 and hmac are not actually used in the current implementation
 
-/// The Curve25519 base field modulus
-/// p = 2^255 - 19
-/// Note: This constant is used in the reduce() method as a hardcoded value
-#[allow(dead_code)]
-const P: [u64; 4] =
-    [0xFFFF_FFFF_FFFF_FFED, 0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF, 0x7FFF_FFFF_FFFF_FFFF];
-
 /// The Curve25519 scalar field modulus (curve order)
 /// l = 2^252 + 27742317777372353535851937790883648493
 const L: [u64; 4] =


### PR DESCRIPTION
🎯 **What:** Removed the unused `P` constant and its associated doc comments from `curve25519.rs`.
💡 **Why:** The constant was marked with `#[allow(dead_code)]` and the `reduce()` method uses a hardcoded value instead, making this clear dead code. Removing it improves codebase maintainability and readability by eliminating unnecessary clutter.
✅ **Verification:** Verified with `cargo test -p forge-ec-curves --lib curve25519` and `cargo check` that the code compiles and all relevant tests continue to pass.
✨ **Result:** Cleaned up unused dead code while preserving all existing functionality.

---
*PR created automatically by Jules for task [7569149034983331903](https://jules.google.com/task/7569149034983331903) started by @tanm-sys*