### PR TITLE
🧪 Add tests for Error enum variants

### DIFF
--- a/forge-ec-core/src/lib.rs
+++ b/forge-ec-core/src/lib.rs
@@ -1885,3 +1885,31 @@ pub mod test_utils {
         true
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn test_error_display() {
+        use alloc::string::ToString;
+
+        assert_eq!(Error::InvalidEncoding.to_string(), "Invalid encoding format");
+        assert_eq!(Error::InvalidSignature.to_string(), "Invalid signature");
+        assert_eq!(Error::InvalidPublicKey.to_string(), "Invalid public key");
+        assert_eq!(Error::InvalidPrivateKey.to_string(), "Invalid private key");
+        assert_eq!(Error::PointNotOnCurve.to_string(), "Point not on the curve");
+        assert_eq!(Error::InvalidFieldElement.to_string(), "Invalid field element");
+        assert_eq!(Error::InvalidScalar.to_string(), "Invalid scalar value");
+        assert_eq!(Error::InvalidCurveParameters.to_string(), "Invalid curve parameters");
+        assert_eq!(Error::CofactorError.to_string(), "Cofactor-related error");
+        assert_eq!(Error::DomainSeparationFailure.to_string(), "Domain separation failure");
+        assert_eq!(Error::InvalidHashToCurveParameters.to_string(), "Invalid hash-to-curve parameters");
+        assert_eq!(Error::KeyExchangeError.to_string(), "Key exchange error");
+        assert_eq!(Error::ValidationError.to_string(), "Validation error");
+        assert_eq!(Error::RandomGenerationFailed.to_string(), "Random number generation failed");
+        assert_eq!(Error::UnsupportedOperation.to_string(), "Operation not supported");
+        assert_eq!(Error::GenericError.to_string(), "Generic error");
+    }
+}


### PR DESCRIPTION
* 🎯 **What:** The testing gap addressed. A missing test module and tests covering the `Display` implementation for the `Error` enum variants.
* 📊 **Coverage:** What scenarios are now tested. The `to_string()` output for every variant of the `Error` enum is now verified.
* ✨ **Result:** The improvement in test coverage. The codebase now ensures that formatting any `Error` variant yields the correct and expected string message, and prevents silent breakage if variants are modified or refactored in the future.

---
*PR created automatically by Jules for task [297977233495019412](https://jules.google.com/task/297977233495019412) started by @tanm-sys*